### PR TITLE
feat: 달력 및 아티 프로필 화면 관련 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Chatting from "./pages/Chatting";
 import ChatRoom from "./pages/ChatRoom";
 import My from "./pages/My";
 import NotFound from "./pages/NotFound";
+import SubscribedArtistList from "./pages/SubscribedArtistList";
 
 const queryClient = new QueryClient();
 
@@ -28,6 +29,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/artist/:artistId" element={<ArtistDetail />} />
           <Route path="/artists" element={<ArtistList />} />
+          <Route path="/subscriptions" element={<SubscribedArtistList />} />
           <Route path="/search" element={<Search />} />
           <Route path="/community" element={<Community />} />
           <Route path="/board/:boardId" element={<BoardList />} />

--- a/src/components/ArtistCarousel.tsx
+++ b/src/components/ArtistCarousel.tsx
@@ -41,7 +41,15 @@ const ArtistCarousel = ({ artists, selectedArtistIds, onArtistSelect }: ArtistCa
             <div className="relative">
               <div className={`w-16 h-16 rounded-full bg-gradient-to-br from-primary/80 to-primary overflow-hidden flex items-center justify-center
                 ring-2 transition-all ${selectedArtistIds.includes(artist.artistId) ? 'ring-primary ring-offset-2 ring-offset-background' : 'ring-transparent'}`}>
-                <img src={artist.profileImageUrl} alt={artist.name} className="w-full h-full object-cover" />
+                {artist.profileImageUrl ? (
+                  <img src={artist.profileImageUrl} alt={artist.name} className="w-full h-full object-cover" />
+                ) : (
+                  <div className="w-full h-full bg-secondary flex items-center justify-center">
+                    <span className="text-lg font-bold text-secondary-foreground">
+                      {artist.name}
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           </button>

--- a/src/components/ArtistCarousel.tsx
+++ b/src/components/ArtistCarousel.tsx
@@ -30,7 +30,7 @@ const ArtistCarousel = () => {
         <div className="flex-1" />
         <button 
           className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          onClick={() => navigate("/artists")}
+          onClick={() => navigate("/subscriptions")}
         >
           + 펼쳐보기 〉
         </button>

--- a/src/components/ArtistCarousel.tsx
+++ b/src/components/ArtistCarousel.tsx
@@ -1,33 +1,20 @@
-import { Plus, Check } from "lucide-react";
-import { useState } from "react";
+import { Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { SubscribedArtistWithConcerts } from "@/types/subscribedConcerts";
 
-interface Artist {
-  id: number;
-  name: string;
-  image?: string;
-  isFollowing: boolean;
+interface ArtistCarouselProps {
+  artists: SubscribedArtistWithConcerts[];
+  selectedArtistIds: number[];
+  onArtistSelect: (artistId: number) => void;
 }
 
-const ArtistCarousel = () => {
+const ArtistCarousel = ({ artists, selectedArtistIds, onArtistSelect }: ArtistCarouselProps) => {
   const navigate = useNavigate();
-  const [artists, setArtists] = useState<Artist[]>([
-    { id: 1, name: "실리카겔", isFollowing: true },
-    { id: 2, name: "길어지면...", isFollowing: false },
-    { id: 3, name: "아티스트명", isFollowing: true },
-    { id: 4, name: "아티스트명", isFollowing: false },
-  ]);
-
-  const toggleFollow = (id: number) => {
-    setArtists(artists.map(artist => 
-      artist.id === id ? { ...artist, isFollowing: !artist.isFollowing } : artist
-    ));
-  };
 
   return (
     <div className="px-6 py-4 border-b border-border">
       <div className="flex items-center justify-between mb-4">
-        <div className="flex-1" />
+        <p className="text-sm font-semibold">구독한 아티스트</p>
         <button 
           className="text-sm text-muted-foreground hover:text-foreground transition-colors"
           onClick={() => navigate("/subscriptions")}
@@ -35,7 +22,7 @@ const ArtistCarousel = () => {
           + 펼쳐보기 〉
         </button>
       </div>
-      <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
+      <div className="flex gap-4 overflow-x-auto py-2 scrollbar-hide">
         <button 
           className="flex-shrink-0 flex flex-col items-center gap-2"
           onClick={() => navigate("/artists")}
@@ -46,31 +33,17 @@ const ArtistCarousel = () => {
         </button>
         {artists.map((artist) => (
           <button
-            key={artist.id}
-            onClick={(e) => {
-              if (e.detail === 2) {
-                // Double click
-                navigate(`/artist/${artist.id}`);
-              } else {
-                // Single click
-                toggleFollow(artist.id);
-              }
-            }}
+            key={artist.artistId}
+            onClick={() => onArtistSelect(artist.artistId)}
+            onDoubleClick={() => navigate(`/artist/${artist.artistId}`)}
             className="flex-shrink-0 flex flex-col items-center gap-2"
           >
             <div className="relative">
-              <div className="w-16 h-16 rounded-full bg-gradient-to-br from-primary/80 to-primary overflow-hidden flex items-center justify-center">
-                <div className="w-full h-full bg-gradient-to-br from-primary/60 to-primary/90" />
+              <div className={`w-16 h-16 rounded-full bg-gradient-to-br from-primary/80 to-primary overflow-hidden flex items-center justify-center
+                ring-2 transition-all ${selectedArtistIds.includes(artist.artistId) ? 'ring-primary ring-offset-2 ring-offset-background' : 'ring-transparent'}`}>
+                <img src={artist.profileImageUrl} alt={artist.name} className="w-full h-full object-cover" />
               </div>
-              {artist.isFollowing && (
-                <div className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full bg-primary flex items-center justify-center border-2 border-background">
-                  <Check className="w-3 h-3 text-primary-foreground" />
-                </div>
-              )}
             </div>
-            <span className="text-xs text-foreground max-w-[70px] truncate">
-              {artist.name}
-            </span>
           </button>
         ))}
       </div>
@@ -79,3 +52,4 @@ const ArtistCarousel = () => {
 };
 
 export default ArtistCarousel;
+

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -48,7 +48,9 @@ const Calendar = ({ onDateSelect, events, selectedDate }: CalendarProps) => {
   };
 
   const goToToday = () => {
-    setCurrentDate(new Date());
+    const today = new Date();
+    setCurrentDate(today);
+    onDateSelect(today);
   };
 
   return (

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,48 +1,43 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CalendarEvent } from "@/types/calendarEvent";
+import { format, isSameDay } from 'date-fns';
 
 interface CalendarProps {
-  onDateSelect?: (date: Date) => void;
-  eventDates?: number[];
+  onDateSelect: (date: Date) => void;
+  events: CalendarEvent[];
+  selectedDate: Date | undefined;
 }
 
-const Calendar = ({ onDateSelect, eventDates = [8, 10, 27, 28] }: CalendarProps) => {
-  const [currentDate, setCurrentDate] = useState(new Date(2025, 11, 1)); // December 2025
-  const [selectedDate, setSelectedDate] = useState<number | null>(null);
+const Calendar = ({ onDateSelect, events, selectedDate }: CalendarProps) => {
+  const [currentDate, setCurrentDate] = useState(new Date());
+
+  const eventDates = useMemo(() => {
+    return new Set(events.map(event => format(new Date(event.date), 'yyyy-MM-dd')));
+  }, [events]);
 
   const daysOfWeek = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
   
   const getDaysInMonth = (date: Date) => {
     const year = date.getFullYear();
     const month = date.getMonth();
-    const firstDay = new Date(year, month, 1).getDay();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const prevMonthDays = new Date(year, month, 0).getDate();
+    const firstDayOfMonth = new Date(year, month, 1);
+    const lastDayOfMonth = new Date(year, month + 1, 0);
     
-    const days: (number | null)[] = [];
-    
-    // Previous month days
-    for (let i = firstDay - 1; i >= 0; i--) {
-      days.push(prevMonthDays - i);
+    const days = [];
+    let day = new Date(firstDayOfMonth);
+    day.setDate(day.getDate() - day.getDay());
+
+    for (let i = 0; i < 42; i++) {
+      days.push(new Date(day));
+      day.setDate(day.getDate() + 1);
     }
-    
-    // Current month days
-    for (let i = 1; i <= daysInMonth; i++) {
-      days.push(i);
-    }
-    
-    // Next month days
-    const remainingDays = 42 - days.length;
-    for (let i = 1; i <= remainingDays; i++) {
-      days.push(i);
-    }
-    
-    return { days, firstDay, daysInMonth };
+    return { days, month };
   };
 
-  const { days, firstDay, daysInMonth } = getDaysInMonth(currentDate);
-  const today = 8; // Based on the reference image
+  const { days, month } = getDaysInMonth(currentDate);
+  const today = new Date();
 
   const goToPrevMonth = () => {
     setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1));
@@ -53,14 +48,7 @@ const Calendar = ({ onDateSelect, eventDates = [8, 10, 27, 28] }: CalendarProps)
   };
 
   const goToToday = () => {
-    setCurrentDate(new Date(2025, 11, 1));
-  };
-
-  const handleDateClick = (day: number, isCurrentMonth: boolean) => {
-    if (isCurrentMonth) {
-      setSelectedDate(day);
-      onDateSelect?.(new Date(currentDate.getFullYear(), currentDate.getMonth(), day));
-    }
+    setCurrentDate(new Date());
   };
 
   return (
@@ -87,7 +75,7 @@ const Calendar = ({ onDateSelect, eventDates = [8, 10, 27, 28] }: CalendarProps)
           <div
             key={day}
             className={`text-xs font-medium text-center py-2 ${
-              index === 0 ? "text-calendar-weekend" : index === 6 ? "text-primary" : "text-foreground"
+              index === 0 ? "text-rose-500" : index === 6 ? "text-blue-500" : "text-foreground"
             }`}
           >
             {day}
@@ -97,28 +85,32 @@ const Calendar = ({ onDateSelect, eventDates = [8, 10, 27, 28] }: CalendarProps)
 
       <div className="grid grid-cols-7 gap-2">
         {days.map((day, index) => {
-          const isCurrentMonth = 
-            (index >= firstDay && index < firstDay + daysInMonth);
-          const isToday = day === today && isCurrentMonth;
-          const hasEvent = day !== null && eventDates.includes(day) && isCurrentMonth;
-          const isWeekend = index % 7 === 0 || index % 7 === 6;
-          
+          const isCurrentMonth = day.getMonth() === month;
+          const isToday = isSameDay(day, today);
+          const dateString = format(day, 'yyyy-MM-dd');
+          const hasEvent = eventDates.has(dateString);
+          const isSelected = selectedDate ? isSameDay(day, selectedDate) : false;
+          const dayOfWeek = day.getDay();
+          const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
           return (
             <button
               key={index}
-              onClick={() => day !== null && handleDateClick(day, isCurrentMonth)}
+              onClick={() => onDateSelect(day)}
               className={`
                 aspect-square rounded-full flex items-center justify-center text-sm font-medium
                 transition-all duration-200
                 ${!isCurrentMonth ? "text-muted-foreground/30" : ""}
-                ${isWeekend && isCurrentMonth ? "text-calendar-weekend" : "text-foreground"}
-                ${isToday ? "ring-2 ring-calendar-today" : ""}
-                ${hasEvent ? "bg-calendar-highlight text-primary-foreground" : ""}
-                ${!hasEvent && isCurrentMonth ? "hover:bg-secondary" : ""}
-                ${selectedDate === day && isCurrentMonth && !hasEvent ? "bg-secondary" : ""}
+                ${isCurrentMonth && isWeekend && dayOfWeek === 0 ? "text-rose-500" : ""}
+                ${isCurrentMonth && isWeekend && dayOfWeek === 6 ? "text-blue-500" : ""}
+                ${isCurrentMonth && !isWeekend ? "text-foreground" : ""}
+                ${isToday ? "ring-2 ring-primary" : ""}
+                ${hasEvent && isCurrentMonth ? "bg-primary/20 text-primary-foreground" : ""}
+                ${isSelected && isCurrentMonth ? "bg-primary text-primary-foreground" : ""}
+                ${!isSelected && isCurrentMonth ? "hover:bg-secondary" : ""}
               `}
             >
-              {day}
+              {day.getDate()}
             </button>
           );
         })}

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,53 +1,96 @@
 import { useNavigate } from "react-router-dom";
 import { Card } from "@/components/ui/card";
+import { CalendarEvent } from "@/types/calendarEvent";
+import { useMemo } from "react";
+import { format } from "date-fns";
 
-interface Event {
-  id: number;
-  artist: string;
-  title: string;
-  date: string;
-  location: string;
-  category: string;
-  image?: string;
+const getTicketSiteName = (url?: string): string | null => {
+  if (!url) return null;
+  if (url.includes("tickets.interpark.com")) return "NOL 티켓";
+  if (url.includes("ticket.yes24.com")) return "YES24";
+  if (url.includes("ticket.melon.com")) return "멜론 티켓";
+  if (url.includes("ticketlink.co.kr")) return "티켓링크";
+  return null;
+};
+
+interface EventListProps {
+  events: CalendarEvent[];
 }
 
-const EventList = () => {
+const EventList = ({ events }: EventListProps) => {
   const navigate = useNavigate();
-  const events: Event[] = [
-    {
-      id: 1,
-      artist: "실리카겔",
-      title: "2025 연말 콘서트 [어쩌구저쩌구]",
-      date: "12.27(토) - 12.28(일)",
-      location: "콘서트 | 일산 킨텍스",
-      category: "concert",
-    },
-  ];
+
+  const groupedEvents = useMemo(() => {
+    return events.reduce((acc, event) => {
+      if (!acc[event.artistId]) {
+        acc[event.artistId] = {
+          artistId: event.artistId,
+          artistName: event.artistName,
+          artistProfileImageUrl: event.artistProfileImageUrl, 
+          events: [],
+        };
+      }
+      acc[event.artistId].events.push(event);
+      return acc;
+    }, {} as Record<number, { artistId: number; artistName: string; artistProfileImageUrl: string; events: CalendarEvent[] }>);
+  }, [events]);
+
+  if (events.length === 0) {
+    return (
+      <div className="px-6 py-10 text-center">
+        <p className="text-muted-foreground">선택된 날짜에 일정이 없습니다.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="px-6 py-4">
-      <h3 
-        className="text-lg font-bold text-foreground mb-4 cursor-pointer hover:text-primary transition-colors"
-        onClick={() => navigate("/artist/1")}
-      >
-        실리카겔
-      </h3>
-      <div className="space-y-4">
-        {events.map((event) => (
-          <Card key={event.id} className="overflow-hidden hover:shadow-lg transition-shadow">
-            <div className="flex gap-4 p-4">
-              <div className="w-20 h-20 rounded-lg bg-muted flex-shrink-0" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm text-muted-foreground mb-1">{event.date}</p>
-                <h4 className="font-semibold text-foreground mb-1 truncate">
-                  {event.title}
-                </h4>
-                <p className="text-sm text-muted-foreground">{event.location}</p>
-              </div>
-            </div>
-          </Card>
-        ))}
-      </div>
+    <div className="px-6 py-4 space-y-6">
+      {Object.values(groupedEvents).map((group) => (
+        <div key={group.artistId}>
+          <div 
+            className="flex items-center gap-2 mb-4 cursor-pointer"
+            onClick={() => navigate(`/artist/${group.artistId}`)}
+          >
+            <h3 className="text-lg font-bold text-foreground hover:text-primary transition-colors">
+              {group.artistName}
+            </h3>
+          </div>
+          <div className="space-y-4">
+            {group.events.map((event) => {
+              const ticketSite = getTicketSiteName(event.bookingUrl);
+              const locationText = event.type === 'booking' 
+                ? `예매 일정 ${ticketSite ? `| ${ticketSite}` : ''}`
+                : event.place;
+              
+              return (
+                <Card 
+                  key={`${event.concertId}-${event.type}-${event.scheduleId || event.dateTime}`} 
+                  className="overflow-hidden hover:shadow-lg transition-shadow"
+                >
+                  <div className="flex gap-4 p-4">
+                    {event.imageUrl ? (
+                      <img src={event.imageUrl} alt={event.title} className="w-20 h-20 rounded-lg object-cover bg-muted flex-shrink-0" />
+                    ) : (
+                      <div className="w-20 h-20 rounded-lg bg-muted flex-shrink-0" />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-muted-foreground mb-1">
+                        {event.type === 'booking' ? '예매' : '공연'} | {format(new Date(event.dateTime), 'MM.dd (E) HH:mm')}
+                      </p>
+                      <h4 className="font-semibold text-foreground mb-1 truncate">
+                        {event.title}
+                      </h4>
+                      <p className="text-sm text-muted-foreground">
+                        {locationText}
+                      </p>
+                    </div>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,94 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * 단일 날짜를 KST 기준으로 'M.D(요일) HH:mm' 형식으로 변환합니다.
+ * @param date Date 객체
+ */
+const formatScheduleDateTime = (date: Date): string => {
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+};
+
+/**
+ * 공연 일정 배열을 KST 기준으로 포맷팅합니다.
+ * 연속된 날짜는 범위로, 떨어진 날짜는 쉼표로 구분합니다.
+ * @param dates ISO 날짜 문자열 배열
+ */
+export function formatPerformingSchedule(dates: string[]): string {
+  if (!dates || dates.length === 0) {
+    return '';
+  }
+
+  const sortedDates = dates.map(d => new Date(d)).sort((a, b) => a.getTime() - b.getTime());
+
+  if (sortedDates.length === 1) {
+    return formatScheduleDateTime(sortedDates[0]);
+  }
+
+  const ranges: Date[][] = [];
+  let currentRange: Date[] = [sortedDates[0]];
+
+  for (let i = 1; i < sortedDates.length; i++) {
+    const prevDate = sortedDates[i - 1];
+    const currentDate = sortedDates[i];
+    
+    // KST 기준으로 날짜의 시작을 계산하여 비교
+    const prevDateKSTStart = new Date(prevDate.toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+    prevDateKSTStart.setHours(0, 0, 0, 0);
+    const currentDateKSTStart = new Date(currentDate.toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+    currentDateKSTStart.setHours(0, 0, 0, 0);
+
+    const diffTime = currentDateKSTStart.getTime() - prevDateKSTStart.getTime();
+    const diffDays = Math.round(diffTime / (1000 * 3600 * 24));
+
+    if (diffDays === 1) {
+      currentRange.push(currentDate);
+    } else {
+      ranges.push(currentRange);
+      currentRange = [currentDate];
+    }
+  }
+  ranges.push(currentRange);
+
+  return ranges
+    .map(range => {
+      if (range.length === 1) {
+        return formatScheduleDateTime(range[0]);
+      } else {
+        // 시작일과 종료일의 시간이 다를 수 있으므로 전체 포맷을 보여줌
+        return `${formatScheduleDateTime(range[0])} - ${formatScheduleDateTime(range[range.length - 1])}`;
+      }
+    })
+    .join(', ');
+}
+
+/**
+ * ISO 날짜 문자열을 KST 기준으로 'YYYY.MM.DD HH:mm' 형식으로 변환합니다.
+ * @param isoString ISO 날짜 문자열
+ */
+export function formatDateTime(isoString: string): string {
+  if (!isoString || isoString === 'null') {
+    return '';
+  }
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
+  
+  const year = date.toLocaleString('en-CA', { timeZone: 'Asia/Seoul', year: 'numeric' });
+  const month = date.toLocaleString('en-CA', { timeZone: 'Asia/Seoul', month: '2-digit' });
+  const day = date.toLocaleString('en-CA', { timeZone: 'Asia/Seoul', day: '2-digit' });
+  const hour = date.toLocaleString('en-GB', { timeZone: 'Asia/Seoul', hour: '2-digit', hourCycle: 'h23' });
+  const minute = date.toLocaleString('en-GB', { timeZone: 'Asia/Seoul', minute: '2-digit' });
+
+  return `${year}.${month}.${day} ${hour}:${minute}`;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -95,3 +95,17 @@ export function formatDateTime(isoString: string): string {
 
   return `${year}.${month}.${day} ${hour}:${minute}`;
 }
+
+/**
+ * 두 Date 객체가 같은 날짜인지 확인합니다. (시간 무시)
+ * @param date1 Date
+ * @param date2 Date
+ */
+export function isSameDay(date1: Date, date2: Date): boolean {
+  if (!date1 || !date2) return false;
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}

--- a/src/pages/ArtistDetail.tsx
+++ b/src/pages/ArtistDetail.tsx
@@ -1,21 +1,49 @@
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, ChevronRight } from "lucide-react";
+import { ArrowLeft, ChevronRight, Link } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import apiClient from "@/lib/api";
+import { Artist } from "@/types/artist";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const ArtistDetail = () => {
-  const { artistId } = useParams();
+  const { artistId } = useParams<{ artistId: string }>();
   const navigate = useNavigate();
 
-  // Mock data - 실제로는 artistId로 데이터를 가져와야 함
-  const artist = {
-    id: artistId,
-    name: "실리카겔",
-    description: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
-    image: "",
-  };
+  const [artist, setArtist] = useState<Artist | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!artistId) return;
+
+    const fetchArtist = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await apiClient.get<{ success: boolean; data: Artist; message: string }>(
+          `/api/artists/${artistId}`
+        );
+        if (response.data.success) {
+          setArtist(response.data.data);
+        } else {
+          throw new Error(response.data.message || 'Failed to fetch artist data');
+        }
+      } catch (err) {
+        setError("아티스트 정보를 불러오는 데 실패했습니다.");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchArtist();
+  }, [artistId]);
+
+  // Mock data for concerts (can be replaced with API data later)
   const concerts = [
     {
       id: 1,
@@ -31,9 +59,44 @@ const ArtistDetail = () => {
     },
   ];
 
+  if (loading) {
+    return (
+      <div className="p-6">
+        <Skeleton className="h-10 w-10 mb-4" />
+        <div className="space-y-4">
+          <Skeleton className="h-[280px] w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="text-center py-12 text-destructive">{error}</div>;
+  }
+
+  if (!artist) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        아티스트를 찾을 수 없습니다.
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-background">
       <div className="relative h-[280px] bg-gradient-to-b from-primary/20 to-background">
+        {artist.profileImageUrl ? (
+          <img
+            src={artist.profileImageUrl}
+            alt={artist.name}
+            className="absolute inset-0 w-full h-full object-cover opacity-30"
+          />
+        ) : (
+          <div className="absolute inset-0 w-full h-full bg-muted opacity-50" />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-background via-background/70 to-transparent" />
         <Button
           variant="ghost"
           size="icon"
@@ -42,12 +105,13 @@ const ArtistDetail = () => {
         >
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <div className="absolute bottom-6 left-6 right-6">
-          <h1 className="text-3xl font-bold text-foreground mb-2">{artist.name}</h1>
-          <p className="text-sm text-muted-foreground line-clamp-2">{artist.description}</p>
-          <Button variant="secondary" size="sm" className="mt-4">
-            인디플
-          </Button>
+        <div className="absolute bottom-6 left-6 right-6 z-10">
+          <h1 className="text-3xl font-bold text-foreground mb-2">
+            {artist.name}
+          </h1>
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {artist.description}
+          </p>
         </div>
       </div>
 
@@ -71,11 +135,15 @@ const ArtistDetail = () => {
               <div className="flex gap-4 p-4">
                 <div className="w-20 h-20 rounded-lg bg-muted flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm text-muted-foreground mb-1">{concert.date}</p>
+                  <p className="text-sm text-muted-foreground mb-1">
+                    {concert.date}
+                  </p>
                   <h4 className="font-semibold text-foreground mb-1 truncate">
                     {concert.title}
                   </h4>
-                  <p className="text-sm text-muted-foreground">{concert.location}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {concert.location}
+                  </p>
                 </div>
               </div>
             </Card>
@@ -83,37 +151,60 @@ const ArtistDetail = () => {
         </TabsContent>
 
         <TabsContent value="albums" className="space-y-4">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-foreground">앨범</h3>
-            <button className="flex items-center text-sm text-muted-foreground hover:text-foreground">
-              더보기 <ChevronRight className="h-4 w-4" />
-            </button>
-          </div>
-          <div className="grid grid-cols-3 gap-4">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="space-y-2">
-                <div className="aspect-square rounded-lg bg-muted" />
-                <p className="text-sm text-foreground">앨범명</p>
-              </div>
-            ))}
+          {/* Album content can be fetched and displayed here */}
+           <div className="text-center py-12 text-muted-foreground">
+            앨범 정보가 없습니다
           </div>
         </TabsContent>
-
         <TabsContent value="posts" className="space-y-4">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-foreground">게시글</h3>
-            <button className="flex items-center text-sm text-muted-foreground hover:text-foreground">
-              더보기 <ChevronRight className="h-4 w-4" />
-            </button>
-          </div>
-          <div className="text-center py-12 text-muted-foreground">
+          {/* Posts content can be fetched and displayed here */}
+           <div className="text-center py-12 text-muted-foreground">
             게시글이 없습니다
           </div>
         </TabsContent>
 
-        <TabsContent value="info" className="space-y-4">
-          <h3 className="text-lg font-semibold text-foreground mb-4">아티스트 정보</h3>
-          <p className="text-foreground">{artist.description}</p>
+        <TabsContent value="info" className="space-y-6">
+          <div>
+            <h3 className="text-lg font-semibold text-foreground mb-2">소개</h3>
+            <p className="text-foreground whitespace-pre-wrap">
+              {artist.description || "아직 소개가 등록되지 않았습니다."}
+            </p>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-foreground mb-2">장르</h3>
+            {artist.genre && artist.genre.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {artist.genre.map((g) => (
+                  <Badge key={g} variant="secondary">
+                    {g}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">다양한 장르의 음악을 하고 있어요.</p>
+            )}
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-foreground mb-2">SNS</h3>
+            {artist.sns && artist.sns.length > 0 ? (
+              <div className="space-y-2">
+                {artist.sns.map((s) => (
+                  <a
+                    key={s.platform}
+                    href={s.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center text-sm text-foreground hover:underline"
+                  >
+                    <Link className="h-4 w-4 mr-2 text-muted-foreground" />
+                    {s.platform}
+                  </a>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">아직 SNS 정보를 등록하지 않았어요.</p>
+            )}
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/pages/ArtistList.tsx
+++ b/src/pages/ArtistList.tsx
@@ -1,24 +1,30 @@
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import apiClient from "@/lib/api";
+import { Artist, ArtistsApiResponse } from "@/types/artist";
 
 const ArtistList = () => {
   const navigate = useNavigate();
+  const [artists, setArtists] = useState<Artist[]>([]);
 
-  const artists = [
-    { id: 1, name: "실리카겔" },
-    { id: 2, name: "길어지면..." },
-    { id: 3, name: "아티스트명" },
-    { id: 4, name: "아티스트명" },
-    { id: 5, name: "아티스트명" },
-    { id: 6, name: "아티스트명" },
-    { id: 7, name: "아티스트명" },
-    { id: 8, name: "아티스트명" },
-    { id: 9, name: "아티스트명" },
-    { id: 10, name: "아티스트명" },
-    { id: 11, name: "아티스트명" },
-    { id: 12, name: "아티스트명" },
-  ];
+  useEffect(() => {
+    const fetchArtists = async () => {
+      try {
+        const response = await apiClient.get<ArtistsApiResponse>('/api/artists');
+        if (response.data.success) {
+          setArtists(response.data.data.artists);
+        } else {
+          console.error("Failed to fetch artists:", response.data.message);
+        }
+      } catch (error) {
+        console.error("An error occurred while fetching artists:", error);
+      }
+    };
+
+    fetchArtists();
+  }, []);
 
   return (
     <div className="min-h-screen bg-background">
@@ -36,16 +42,24 @@ const ArtistList = () => {
 
       <main className="px-6 py-6">
         <p className="text-sm text-muted-foreground mb-6">
-          추가하고 싶은 아티스트를 검색해보세요.
+          추가하고 싶은 아티스트를 선택하세요.
         </p>
         <div className="grid grid-cols-3 gap-4">
           {artists.map((artist) => (
             <button
-              key={artist.id}
-              onClick={() => navigate(`/artist/${artist.id}`)}
+              key={artist.artistId}
+              onClick={() => navigate(`/artist/${artist.artistId}`)}
               className="flex flex-col items-center gap-2"
             >
-              <div className="w-full aspect-square rounded-full bg-gradient-to-br from-primary/60 to-primary/90 overflow-hidden" />
+              <div className="w-full aspect-square rounded-full bg-secondary overflow-hidden flex items-center justify-center">
+                {artist.profileImageUrl ? (
+                  <img src={artist.profileImageUrl} alt={artist.name} className="w-full h-full object-cover" />
+                ) : (
+                  <span className="text-2xl font-bold text-secondary-foreground">
+                    {artist.name}
+                  </span>
+                )}
+              </div>
               <span className="text-sm text-foreground truncate w-full text-center">
                 {artist.name}
               </span>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import ArtistCarousel from "@/components/ArtistCarousel";
 import Calendar from "@/components/Calendar";
 import EventList from "@/components/EventList";
 import BottomNav from "@/components/BottomNav";
+import apiClient from "@/lib/api";
 import { SubscribedArtistWithConcerts } from "@/types/subscribedConcerts";
 import { CalendarEvent } from "@/types/calendarEvent";
 import { format, isSameDay } from 'date-fns';
@@ -16,56 +17,14 @@ const Index = () => {
   useEffect(() => {
     const fetchConcerts = async () => {
       try {
-        // Mock Data for UI development
-        const mockResponse = {
-          success: true,
-          data: {
-            artists: [
-              {
-                artistId: 1,
-                name: "실리카겔",
-                profileImageUrl: "https://via.placeholder.com/150",
-                subscribedAt: "2025-01-01T00:00:00Z",
-                concerts: [
-                  {
-                    concertId: 101,
-                    title: "실리카겔 연말 단독 콘서트",
-                    place: "블루스퀘어 마스터카드홀",
-                    performingSchedule: [
-                      { id: 1, date: "2025-12-27T19:00:00Z" },
-                      { id: 2, date: "2025-12-28T18:00:00Z" },
-                    ],
-                    bookingSchedule: "2025-12-10T14:00:00Z",
-                    bookingUrl: "https://tickets.interpark.com/goods/25000001",
-                    imageUrl: "https://via.placeholder.com/150/FFC0CB/000000?Text=Silica"
-                  },
-                ],
-              },
-              {
-                artistId: 2,
-                name: "파란노을",
-                profileImageUrl: "https://via.placeholder.com/150/ADD8E6/000000?Text=Paran",
-                subscribedAt: "2025-02-01T00:00:00Z",
-                concerts: [
-                  {
-                    concertId: 102,
-                    title: "After the Magic Tour",
-                    place: "KT&G 상상마당",
-                    performingSchedule: [
-                      { id: 3, date: "2025-12-20T20:00:00Z" },
-                    ],
-                    bookingSchedule: "2025-12-08T20:00:00Z",
-                    bookingUrl: "https://ticket.yes24.com/Perf/49001",
-                    imageUrl: "https://via.placeholder.com/150/ADD8E6/000000?Text=Paran"
-                  },
-                ],
-              },
-            ],
-          },
-          message: "성공",
-        };
-        setArtists(mockResponse.data.artists);
-
+        const response = await apiClient.get<{ success: boolean; data: { artists: SubscribedArtistWithConcerts[] }; message: string }>(
+          "/api/concerts/subscribed"
+        );
+        if (response.data.success) {
+          setArtists(response.data.data.artists);
+        } else {
+          console.error("Failed to fetch subscribed concerts:", response.data.message);
+        }
       } catch (error) {
         console.error("Failed to fetch subscribed concerts:", error);
       }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,18 +1,156 @@
+import { useState, useEffect, useMemo } from "react";
 import Header from "@/components/Header";
 import ArtistCarousel from "@/components/ArtistCarousel";
 import Calendar from "@/components/Calendar";
 import EventList from "@/components/EventList";
 import BottomNav from "@/components/BottomNav";
+import { SubscribedArtistWithConcerts } from "@/types/subscribedConcerts";
+import { CalendarEvent } from "@/types/calendarEvent";
+import { format, isSameDay } from 'date-fns';
 
 const Index = () => {
+  const [artists, setArtists] = useState<SubscribedArtistWithConcerts[]>([]);
+  const [selectedArtistIds, setSelectedArtistIds] = useState<number[]>([]);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+
+  useEffect(() => {
+    const fetchConcerts = async () => {
+      try {
+        // Mock Data for UI development
+        const mockResponse = {
+          success: true,
+          data: {
+            artists: [
+              {
+                artistId: 1,
+                name: "실리카겔",
+                profileImageUrl: "https://via.placeholder.com/150",
+                subscribedAt: "2025-01-01T00:00:00Z",
+                concerts: [
+                  {
+                    concertId: 101,
+                    title: "실리카겔 연말 단독 콘서트",
+                    place: "블루스퀘어 마스터카드홀",
+                    performingSchedule: [
+                      { id: 1, date: "2025-12-27T19:00:00Z" },
+                      { id: 2, date: "2025-12-28T18:00:00Z" },
+                    ],
+                    bookingSchedule: "2025-12-10T14:00:00Z",
+                    bookingUrl: "https://tickets.interpark.com/goods/25000001",
+                    imageUrl: "https://via.placeholder.com/150/FFC0CB/000000?Text=Silica"
+                  },
+                ],
+              },
+              {
+                artistId: 2,
+                name: "파란노을",
+                profileImageUrl: "https://via.placeholder.com/150/ADD8E6/000000?Text=Paran",
+                subscribedAt: "2025-02-01T00:00:00Z",
+                concerts: [
+                  {
+                    concertId: 102,
+                    title: "After the Magic Tour",
+                    place: "KT&G 상상마당",
+                    performingSchedule: [
+                      { id: 3, date: "2025-12-20T20:00:00Z" },
+                    ],
+                    bookingSchedule: "2025-12-08T20:00:00Z",
+                    bookingUrl: "https://ticket.yes24.com/Perf/49001",
+                    imageUrl: "https://via.placeholder.com/150/ADD8E6/000000?Text=Paran"
+                  },
+                ],
+              },
+            ],
+          },
+          message: "성공",
+        };
+        setArtists(mockResponse.data.artists);
+
+      } catch (error) {
+        console.error("Failed to fetch subscribed concerts:", error);
+      }
+    };
+
+    fetchConcerts();
+  }, []);
+
+  const allCalendarEvents = useMemo((): CalendarEvent[] => {
+    return artists.flatMap(artist =>
+      artist.concerts.flatMap(concert => {
+        const performanceEvents: CalendarEvent[] = concert.performingSchedule.map(schedule => ({
+          artistId: artist.artistId,
+          artistName: artist.name,
+          artistProfileImageUrl: artist.profileImageUrl,
+          concertId: concert.concertId,
+          scheduleId: schedule.id,
+          date: format(new Date(schedule.date), 'yyyy-MM-dd'),
+          dateTime: schedule.date,
+          title: concert.title,
+          place: concert.place,
+          type: 'performance',
+          bookingUrl: concert.bookingUrl,
+          imageUrl: concert.imageUrl,
+        }));
+
+        const bookingEvent: CalendarEvent = {
+          artistId: artist.artistId,
+          artistName: artist.name,
+          artistProfileImageUrl: artist.profileImageUrl,
+          concertId: concert.concertId,
+          date: format(new Date(concert.bookingSchedule), 'yyyy-MM-dd'),
+          dateTime: concert.bookingSchedule,
+          title: concert.title,
+          place: '예매 일정',
+          type: 'booking',
+          bookingUrl: concert.bookingUrl,
+          imageUrl: concert.imageUrl,
+        };
+
+        return [...performanceEvents, bookingEvent];
+      })
+    );
+  }, [artists]);
+
+  const filteredEvents = useMemo(() => {
+    if (selectedArtistIds.length === 0) {
+      return allCalendarEvents;
+    }
+    return allCalendarEvents.filter(event => selectedArtistIds.includes(event.artistId));
+  }, [allCalendarEvents, selectedArtistIds]);
+
+  const dailyEvents = useMemo(() => {
+    if (!selectedDate) return [];
+    return filteredEvents.filter(event => isSameDay(new Date(event.date), selectedDate));
+  }, [filteredEvents, selectedDate]);
+
+  const handleArtistSelect = (artistId: number) => {
+    setSelectedArtistIds(prevIds => 
+      prevIds.includes(artistId) 
+        ? prevIds.filter(id => id !== artistId)
+        : [...prevIds, artistId]
+    );
+  };
+
+  const handleDateSelect = (date: Date) => {
+    setSelectedDate(date);
+  };
+
   return (
     <div className="min-h-screen bg-background pb-20">
       <Header />
       <main className="max-w-screen-xl mx-auto">
-        <ArtistCarousel />
-        <Calendar eventDates={[8, 10, 27, 28]} />
+        <ArtistCarousel
+          artists={artists}
+          selectedArtistIds={selectedArtistIds}
+          onArtistSelect={handleArtistSelect}
+        />
+        <Calendar
+          events={filteredEvents}
+          onDateSelect={handleDateSelect}
+          selectedDate={selectedDate}
+        />
         <div className="h-4 bg-muted/30" />
-        <EventList />
+        <EventList events={dailyEvents} />
       </main>
       <BottomNav />
     </div>

--- a/src/pages/SubscribedArtistList.tsx
+++ b/src/pages/SubscribedArtistList.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import apiClient from "@/lib/api";
+import { SubscribedArtist } from "@/types/subscription";
+
+const SubscribedArtistList = () => {
+  const navigate = useNavigate();
+  const [artists, setArtists] = useState<SubscribedArtist[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchSubscribedArtists = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await apiClient.get<{ success: boolean; data: SubscribedArtist[]; message: string }>(
+          "/api/subscriptions"
+        );
+        if (response.data.success) {
+          const sortedArtists = response.data.data.sort((a, b) =>
+            a.artistName.localeCompare(b.artistName, 'ko')
+          );
+          setArtists(sortedArtists);
+        } else {
+          throw new Error(response.data.message || 'Failed to fetch subscribed artists');
+        }
+      } catch (err) {
+        setError("구독한 아티스트 목록을 불러오는 데 실패했습니다.");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSubscribedArtists();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-50 bg-background border-b border-border px-6 py-4">
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+            <X className="h-5 w-5" />
+          </Button>
+          <h1 className="text-lg font-semibold text-foreground">구독한 아티스트 목록</h1>
+          <div className="w-9 h-9" /> {/* Placeholder for centering title */}
+        </div>
+      </header>
+
+      <main className="px-6 py-6">
+        {loading ? (
+          <div className="grid grid-cols-3 gap-4">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="flex flex-col items-center gap-2">
+                <Skeleton className="w-full aspect-square rounded-full" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div className="text-center py-12 text-destructive">{error}</div>
+        ) : artists.length > 0 ? (
+          <div className="grid grid-cols-3 gap-4">
+            {artists.map((artist) => (
+              <button
+                key={artist.artiProfileId}
+                onClick={() => navigate(`/artist/${artist.artiProfileId}`)}
+                className="flex flex-col items-center gap-2"
+              >
+                <div className="w-full aspect-square rounded-full bg-muted overflow-hidden">
+                  {artist.profileImage ? (
+                    <img src={artist.profileImage} alt={artist.artistName} className="w-full h-full object-cover" />
+                  ) : (
+                    <div className="w-full h-full bg-secondary" />
+                  )}
+                </div>
+                <span className="text-sm text-foreground truncate w-full text-center">
+                  {artist.artistName}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12 text-muted-foreground">
+            구독한 아티스트가 없습니다.
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default SubscribedArtistList;

--- a/src/types/album.ts
+++ b/src/types/album.ts
@@ -1,0 +1,6 @@
+export interface Album {
+  albumId: number;
+  name: string;
+  coverImageUrl: string;
+  releaseDate: string;
+}

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -1,0 +1,13 @@
+export interface SnsLink {
+  platform: string;
+  url: string;
+}
+
+export interface Artist {
+  artistId: number;
+  name: string;
+  profileImageUrl: string;
+  description: string;
+  genre: string[];
+  sns: SnsLink[];
+}

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -3,11 +3,26 @@ export interface SnsLink {
   url: string;
 }
 
-export interface Artist {
+export interface ArtistDetail {
   artistId: number;
   name: string;
   profileImageUrl: string;
   description: string;
   genre: string[];
   sns: SnsLink[];
+}
+
+export interface Artist {
+  artistId: number;
+  name: string;
+  profileImageUrl: string;
+  createdAt: string;
+}
+
+export interface ArtistsApiResponse {
+  success: boolean;
+  data: {
+    artists: Artist[];
+  };
+  message: string;
 }

--- a/src/types/calendarEvent.ts
+++ b/src/types/calendarEvent.ts
@@ -1,7 +1,7 @@
 export interface CalendarEvent {
   artistId: number;
   artistName: string;
-  artistProfileImageUrl: string;
+  artistProfileImageUrl?: string;
   concertId: number;
   scheduleId?: number; // For unique key generation
   date: string; // YYYY-MM-DD format for calendar highlighting

--- a/src/types/calendarEvent.ts
+++ b/src/types/calendarEvent.ts
@@ -1,0 +1,14 @@
+export interface CalendarEvent {
+  artistId: number;
+  artistName: string;
+  artistProfileImageUrl: string;
+  concertId: number;
+  scheduleId?: number; // For unique key generation
+  date: string; // YYYY-MM-DD format for calendar highlighting
+  dateTime: string; // Full ISO string for list display
+  title: string;
+  place: string;
+  type: 'performance' | 'booking';
+  bookingUrl?: string;
+  imageUrl?: string;
+}

--- a/src/types/concert.ts
+++ b/src/types/concert.ts
@@ -1,0 +1,16 @@
+export interface PerformingSchedule {
+  id: number;
+  date: string;
+}
+
+export interface Concert {
+  concertId: number;
+  title: string;
+  place: string;
+  posterImageUrl: string;
+  information: string;
+  bookingSchedule: string;
+  bookingUrl: string;
+  performingSchedule: PerformingSchedule[];
+  createdAt: string;
+}

--- a/src/types/subscribedConcerts.ts
+++ b/src/types/subscribedConcerts.ts
@@ -16,7 +16,7 @@ export interface Concert {
 export interface SubscribedArtistWithConcerts {
   artistId: number;
   name: string;
-  profileImageUrl: string;
+  profileImageUrl?: string;
   subscribedAt: string;
   concerts: Concert[];
 }

--- a/src/types/subscribedConcerts.ts
+++ b/src/types/subscribedConcerts.ts
@@ -1,0 +1,30 @@
+export interface PerformingSchedule {
+  id: number;
+  date: string;
+}
+
+export interface Concert {
+  concertId: number;
+  title: string;
+  place: string;
+  performingSchedule: PerformingSchedule[];
+  bookingSchedule: string;
+  bookingUrl?: string;
+  imageUrl?: string;
+}
+
+export interface SubscribedArtistWithConcerts {
+  artistId: number;
+  name: string;
+  profileImageUrl: string;
+  subscribedAt: string;
+  concerts: Concert[];
+}
+
+export interface SubscribedConcertsApiResponse {
+  success: boolean;
+  data: {
+    artists: SubscribedArtistWithConcerts[];
+  };
+  message: string;
+}

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -1,0 +1,5 @@
+export interface SubscribedArtist {
+  artiProfileId: number;
+  artistName: string;
+  profileImage: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8000,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {


### PR DESCRIPTION
## 메인 화면 (달력)
- 달력에 구독한 아티스트의 공연 정보 조회 API를 연동하였습니다.
- '일정'을 기준으로 이벤트 목록이 렌더링됩니다.
  - 일정이 공연일 경우 장소가 표시됩니다.
  - 일정이 예매 일정일 경우 '예매 일정' 문자열이 표시되며, 예매 url을 파싱하여 'NOL 티켓, YES24, 멜론 티켓, 티켓링크'에 해당한다면 화면에 추가로 렌더링됩니다.
- 'TODAY' 버튼을 누르면 달력 상 오늘 날짜로 전환됩니다.
- 아티스트 목록에서 아티스트를 선택(복수 가능)할 때마다 달력에 표시되는 일정이 변경됩니다.
  - 아무것도 선택하지 않으면 전체 선택으로 간주하고, 모든 일정이 렌더링됩니다.
- 펼쳐보기를 눌렀을 때 내가 구독한 아티스트 목록 API 요청을 수행합니다.
- 플러스 버튼을 눌렀을 때 전체 아티스트 목록 API 요청을 수행합니다. (추후 검색 도입 필요)
## 아티 프로필
- 구독 목록 또는 이벤트 리스트에서 아티 프로필에 진입할 수 있습니다. API 요청으로 아티 프로필 세부 정보, 아티스트의 공연/앨범 목록을 가져옵니다.
  - 세부 정보 중 소개글, sns, 장르는 '정보' 탭에서 확인할 수 있습니다.