### PR TITLE
fix: vercel.json rewrites 규칙 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/:path*",
+      "source": "/(.*)",
       "destination": "/"
     }
   ]


### PR DESCRIPTION
- destination을 /로 변경하여 Vercel 자동 라우팅 활용
- Serverless Functions가 rewrites보다 우선순위를 가지도록 설정