### PR TITLE
fix: vercel.json 제거하여 Serverless Functions 자동 라우팅 활성화

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/"
-    }
-  ]
-}


### PR DESCRIPTION
- rewrites 규칙이 /api/* 경로를 방해하여 Serverless Function이 실행되지 않음
- vercel.json 제거로 Vercel의 자동 라우팅 활용
- SPA 라우팅은 클라이언트 측 라우터가 처리